### PR TITLE
fix: bump ws to ^8.21.0 to patch CVE-2026-48779 (HIGH 7.5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@malinamnam/pi-phone",
       "version": "0.0.13",
       "dependencies": {
-        "ws": "^8.18.3"
+        "ws": "^8.21.0"
       },
       "devDependencies": {
         "@types/ws": "^8.18.1"
@@ -42,9 +42,9 @@
       "license": "MIT"
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     ]
   },
   "dependencies": {
-    "ws": "^8.18.3"
+    "ws": "^8.21.0"
   },
   "devDependencies": {
     "@types/ws": "^8.18.1"


### PR DESCRIPTION
Bumps `ws` from `^8.18.3` to `^8.21.0` to fix [CVE-2026-48779](https://github.com/websockets/ws/security/advisories/GHSA-96hv-2xvq-fx4p) — memory exhaustion DoS (CVSS 7.5). Also fixes CVE-2026-45736 (uninitialized memory disclosure).\n\nAfter bump: `npm audit` reports 0 vulnerabilities.