### PR TITLE
fix: phone UI returns 403 Forbidden on Windows (leading backslash in path normalize)

### DIFF
--- a/src/extension/phone-static.ts
+++ b/src/extension/phone-static.ts
@@ -19,7 +19,13 @@ export const mimeTypes: Record<string, string> = {
 };
 
 export function sanitizePublicPath(pathname: string): string | null {
-  const normalized = normalize(pathname).replace(/^\/+/, "");
+  // Strip leading slashes AND backslashes. On Windows, `normalize("/index.html")`
+  // yields `"\index.html"` (leading backslash); the old `/^\/+ /` only removed
+  // forward slashes, so `resolve(publicDir, "\index.html")` treated the
+  // leading backslash as an absolute path (-> `C:\index.html`), which fails the
+  // `startsWith(publicDir)` check and 403s every static-file request — including
+  // the index page, so the phone UI never loads on Windows.
+  const normalized = normalize(pathname).replace(/^[\\/]+/, "");
   const filePath = resolve(publicDir, normalized === "" ? "index.html" : normalized);
   if (!filePath.startsWith(publicDir)) return null;
   return filePath;


### PR DESCRIPTION
## Problem

On Windows, the phone UI is completely unusable: every request (including the index page at `/`) returns:

```json
{"error":"Forbidden"}
```

The browser never even loads the HTML, so the \"Access token required\" modal never appears and the UI cannot be used at all.

## Root cause

`sanitizePublicPath` in \`src/extension/phone-static.ts\` strips leading slashes with:

\`\`\`ts
const normalized = normalize(pathname).replace(/^\/+/, \"\");
\`\`\`

On **Windows**, \`path.normalize(\"/index.html\")\` returns \`\"\\index.html\"\` (a **leading backslash**), not \`\"index.html\"\`. The regex \`/^\/+/\` only removes forward slashes, so the backslash survives. Then:

\`\`\`ts
resolve(publicDir, \"\\index.html\")
\`\`\`

treats the leading backslash as an **absolute path** and yields \`C:\\index.html\` (drive root), which fails the \`startsWith(publicDir)\` guard → \`sanitizePublicPath\` returns \`null\` → the server responds \`403 Forbidden\`.

On Linux/macOS \`normalize(\"/index.html\")\` returns \`\"index.html\"\` (no leading separator), so the bug is invisible there.

## Fix

Strip **both** leading slashes and backslashes:

\`\`\`ts
const normalized = normalize(pathname).replace(/^[\\/]+/, \"\");
\`\`\`

## Verification (Windows)

Reproduced the resolve behavior with the actual \`publicDir\`:

| pathname       | before (old)   | after (patched) |
|----------------|----------------|-----------------|
| \`/\`              | NULL → 403     | OK              |
| \`/index.html\`    | NULL → 403     | OK              |
| \`/app/main.js\`   | NULL → 403     | OK              |
| \`/styles.css\`    | NULL → 403     | OK              |

Before the fix, \`GET /\` and \`GET /api/health\` both returned \`200\` for \`/api/health\` (it short-circuits before \`sanitizePublicPath\`) but \`403\` for \`/\` — confirming the static-file path is the culprit. After the patch, \`/\` returns the index HTML (\`200\`) and the phone UI loads.

Reported against the latest \`master\` (\`196d6ac\`); also reproduces on the published npm \`0.0.13\`.